### PR TITLE
Add coveralls integration

### DIFF
--- a/.github/workflows/continous_integration.yml
+++ b/.github/workflows/continous_integration.yml
@@ -46,7 +46,7 @@ jobs:
           pip install -e .
 
       - name: Run tests
-        run: pytest
+        run: coverage run -m pytest -v
 
       - name: Run Coveralls
         if: ${{ success() }}

--- a/.github/workflows/continous_integration.yml
+++ b/.github/workflows/continous_integration.yml
@@ -48,13 +48,13 @@ jobs:
       - name: Run tests
         run: pytest
 
-#      - name: Run Coveralls
-#        if: ${{ success() }}
-#        run: |
-#          poetry run coveralls --service=github
-#        env:
-#          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-#
+      - name: Run Coveralls
+        if: ${{ success() }}
+        run: |
+          coveralls --service=github
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
 #      - name: Echo tag name
 #        run: echo "Tag is ${{ github.ref }}, Deploy is ${{ startsWith(github.ref, 'refs/tags/') && matrix.python-version == 3.9}}"
 #

--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
 # gwemopt
 Gravitational-wave Electromagnetic Optimization
 
-[![Coverage Status](https://coveralls.io/repos/github/mcoughlin/gwemopt/badge.svg?branch=main)](https://coveralls.io/github/mcoughlin/gwemopt?branch=main)
-[![CI](https://github.com/mcoughlin/gwemopt/actions/workflows/continous_integration.yml/badge.svg)](https://github.com/mcoughlin/gwemopt/actions/workflows/continous_integration.yml)
+[![Coverage Status](https://coveralls.io/repos/github/skyportal/gwemopt/badge.svg?branch=main)](https://coveralls.io/github/skyportal/gwemopt?branch=main)
+[![CI](https://github.com/skyportal/gwemopt/actions/workflows/continous_integration.yml/badge.svg)](https://github.com/skyportal/gwemopt/actions/workflows/continous_integration.yml)
 [![PyPI version](https://badge.fury.io/py/gwemopt.svg)](https://badge.fury.io/py/gwemopt)
 
 The code currently can:

--- a/README.md
+++ b/README.md
@@ -1,6 +1,10 @@
 # gwemopt
 Gravitational-wave Electromagnetic Optimization
 
+[![Coverage Status](https://coveralls.io/repos/github/mcoughlin/gwemopt/badge.svg?branch=main)](https://coveralls.io/github/mcoughlin/gwemopt?branch=main)
+[![CI](https://github.com/mcoughlin/gwemopt/actions/workflows/continous_integration.yml/badge.svg)](https://github.com/mcoughlin/gwemopt/actions/workflows/continous_integration.yml)
+[![PyPI version](https://badge.fury.io/py/gwemopt.svg)](https://badge.fury.io/py/gwemopt)
+
 The code currently can:
 - interact with gracedb, download the skymaps, read them etc. 
 - read telescope configuration files with location, FOV, limiting magnitude, exposure times, etc.

--- a/setup.py
+++ b/setup.py
@@ -90,7 +90,7 @@ setup(
     author='Michael Coughlin',
     author_email='michael.coughlin@ligo.org',
     license='GPLv3',
-    url='https://github.com/mcoughlin/gwemopt/',
+    url='https://github.com/skyportal/gwemopt/',
 
     # package content
     packages=find_packages(),
@@ -108,6 +108,8 @@ setup(
         'Programming Language :: Python :: 3.7',
         'Programming Language :: Python :: 3.8',
         'Programming Language :: Python :: 3.9',
+        'Programming Language :: Python :: 3.10',
+        'Programming Language :: Python :: 3.11',
         'Intended Audience :: Science/Research',
         'Intended Audience :: End Users/Desktop',
         'Intended Audience :: Developers',

--- a/setup.py
+++ b/setup.py
@@ -75,6 +75,7 @@ install_requires = [
     'freezegun',
     'sqlparse',
     'bs4',
+    "coveralls"
 ]
 
 # -- run setup ----------------------------------------------------------------


### PR DESCRIPTION
Building on CI/tests from #79 , this PR integrates coveralls code coverage checks (we are at 28% now). It also adds CI/PyPi/coverage badges to the readme, and updates the URL in the setup.py.