### PR TITLE
Add python-ligo-lw and ligo-segments to README install instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ Setting up the environment:
 ```
 conda install numpy scipy matplotlib astropy h5py shapely
 conda install -c astropy astroquery
-conda install -c conda-forge voeventlib astropy-healpix
+conda install -c conda-forge voeventlib astropy-healpix python-ligo-lw ligo-segments
 ```
 
 And then setup.py should take care of the rest.


### PR DESCRIPTION
I just made a fresh environment and followed the existing installation instructions in the README, but `python setup.py install` complained until I also installed `python-ligo-lw` and `ligo-segments`.