### PR TITLE
Python 3.8+3.9

### DIFF
--- a/.github/workflows/continous_integration.yml
+++ b/.github/workflows/continous_integration.yml
@@ -26,7 +26,7 @@ jobs:
     # Specify the python versions to test
     strategy:
       matrix:
-        python-version: ["3.10", "3.11"]
+        python-version: ["3.8", "3.9", "3.10", "3.11"]
 
     # Steps represent a sequence of tasks that will be executed as part of the job
     steps:

--- a/gwemopt/gracedb.py
+++ b/gwemopt/gracedb.py
@@ -16,7 +16,7 @@ from gwemopt.paths import SKYMAP_DIR
 def get_event(
         event_name: str,
         output_dir: Path = SKYMAP_DIR,
-        rev: int | None = None,
+        rev = None,
 ):
     """
     Fetches the event info and skymap from GraceDB

--- a/gwemopt/read_output.py
+++ b/gwemopt/read_output.py
@@ -2,7 +2,7 @@ from pathlib import Path
 import pandas as pd
 
 
-def read_schedule(schedule_path: str | Path):
+def read_schedule(schedule_path):
     """
     Reads a schedule file and returns a pandas dataframe
 

--- a/gwemopt/utils/skymap.py
+++ b/gwemopt/utils/skymap.py
@@ -12,7 +12,7 @@ from astropy.io import fits
 from astropy.time import Time
 
 
-def read_skymap(params, do_3d: bool | None = None, map_struct=None):
+def read_skymap(params, do_3d = None, map_struct=None):
 
     # Let's just figure out what's in the skymap first
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,10 +9,12 @@ authors = [
 ]
 description = "A python package for GW-EM Followup Optimization"
 readme = "README.md"
-requires-python = ">=3.10"
+requires-python = ">=3.8"
 license = {text = "GPLv3"}
 classifiers = [
     "Programming Language :: Python :: 3",
+    'Programming Language :: Python :: 3.8',
+    'Programming Language :: Python :: 3.9',
     'Programming Language :: Python :: 3.10',
     'Programming Language :: Python :: 3.11',
     'Intended Audience :: Science/Research',


### PR DESCRIPTION
Damage control from #103, restores compatibility with python 3.8/3.9 by removing futuristic type hints. 