### PR TITLE
Group chipgap scripts, delete unused functions

### DIFF
--- a/gwemopt/chipgaps/__init__.py
+++ b/gwemopt/chipgaps/__init__.py
@@ -1,0 +1,5 @@
+"""
+Module for chip gaps.
+"""
+from gwemopt.chipgaps.decam import get_decam_quadrant_ipix
+from gwemopt.chipgaps.ztf import get_ztf_quadrant_ipix

--- a/gwemopt/chipgaps/decam.py
+++ b/gwemopt/chipgaps/decam.py
@@ -165,18 +165,6 @@ class DECamtile:
         return ccd_cent_xy
 
 
-# class CCDProb:
-#     """
-#     Class :: Instantiate a CCDProb object that will allow us to calculate the
-#              probability content in a single CCD.
-#     """
-#
-#     def __init__(self, RA, Dec):
-#         self.RA = RA
-#         self.Dec = Dec
-#         self.ccd_size = np.array([2046, 4094])
-
-
 def get_decam_ccds(ra, dec, save_footprint=False):
     """Calculate DECam CCD footprints as offsets from the telescope
     boresight. Also optionally saves the footprints in a region file
@@ -240,69 +228,6 @@ def get_decam_quadrant_ipix(nside, ra, dec):
     return ipixs
 
 
-# def get_ccdcenters_radec(filename):
-#     hdul = fits.open(filename)
-#     nccds = len(hdul) - 1
-#     ccd_centers = dict()
-#     for i in range(1, nccds + 1):
-#         w = WCS(hdul[i].header)
-#         ccdnum = hdul[i].header["CCDNUM"]
-#         coords = np.array(
-#             w.wcs_pix2world(
-#                 hdul[i].header["NAXIS1"] / 2, hdul[i].header["NAXIS2"] / 2, 0
-#             )
-#         )
-#         ccd_centers[str(ccdnum)] = coords
-#     hdul.close()
-#     return ccd_centers
-
-
-# def create_region_file(filename):
-#     hdul = fits.open(filename)
-#     nccds = len(hdul) - 1
-#     for i in range(1, nccds + 1):
-#         w = WCS(hdul[i].header)
-#         w.footprint_to_file(
-#             filename="region_files/footprint_" + str(hdul[i].header["CCDNUM"]) + ".reg"
-#         )
-#     hdul.close()
-#
-#
-# def get_cd(filename):
-#     hdul = fits.open(filename)
-#     w = WCS(hdul[1].header)
-#     hdul.close()
-#     return w.wcs.cd
-
-
-# def get_ccdcenters_xy(filename):
-#     "Calculates the x,y coordinates of the CCD center given the RA,Dec of the center and reference point.Uses Calabretta and Greisen(2002) eqns. 5,12,13,54"
-#     ccd_centers_xy = dict()
-#     phi_p = 180 * u.deg
-#     ccd_centers_radec = get_ccdcenters_radec(filename)
-#     hdul = fits.open(filename)
-#     alpha_p = hdul[1].header["CRVAL1"] * u.deg
-#     delta_p = hdul[1].header["CRVAL2"] * u.deg
-#     ccdnums = ccd_centers_radec.keys()
-#     for ccdnum in ccdnums:
-#         alpha = ccd_centers_radec[ccdnum][0] * u.deg
-#         delta = ccd_centers_radec[ccdnum][1] * u.deg
-#         phi = phi_p + np.arctan2(
-#             -np.cos(delta) * np.sin(alpha - alpha_p),
-#             np.sin(delta) * np.cos(delta_p)
-#             - np.cos(delta) * np.sin(delta_p) * np.cos(alpha - alpha_p),
-#         )
-#         theta = np.arcsin(
-#             np.sin(delta) * np.sin(delta_p)
-#             + np.cos(delta) * np.cos(delta_p) * np.cos(alpha - alpha_p)
-#         )
-#         R_theta = (1 * u.rad / np.tan(theta)).to(u.deg)
-#         x = R_theta * np.sin(phi)
-#         y = -R_theta * np.cos(phi)
-#         ccd_centers_xy[ccdnum] = [x.value, y.value]
-#     return ccd_centers_xy
-
-
 def ccd_xy_to_radec(alpha_p, delta_p, ccd_centers_xy):
     # convert to Native longitude (phi) and latitude (theta)
     # need intermediate step (Rtheta) to deal with TAN projection
@@ -345,15 +270,3 @@ def ccd_xy_to_radec(alpha_p, delta_p, ccd_centers_xy):
         alpha[alpha < 0 * u.deg] += 360 * u.deg
         ccd_centers_radec[ccdnum] = np.array([alpha.value, delta.value])
     return ccd_centers_radec
-
-
-# def calculate_residuals(ccd_cent_code, ccd_cent_wcs):
-#     residuals = np.empty([len(ccd_cent_code), 2])
-#     for i, ccdnum in enumerate(ccd_cent_code.keys()):
-#         residuals[i] = np.array(
-#             [
-#                 np.abs(ccd_cent_code[ccdnum][0] - ccd_cent_wcs[ccdnum][0]),
-#                 np.abs(ccd_cent_code[ccdnum][1] - ccd_cent_wcs[ccdnum][1]),
-#             ]
-#         )
-#     return residuals

--- a/gwemopt/chipgaps/decam.py
+++ b/gwemopt/chipgaps/decam.py
@@ -14,22 +14,15 @@
 # with this program; if not, write to the Free Software Foundation, Inc.,
 # 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 
-from __future__ import print_function
-
-import os
-
-# import cPickle as pickle
-import pickle
+"""
+This module contains the DECamtile class, which is used to calculate decam chip gaps
+"""
 
 import astropy
-import healpy
 import healpy as hp
 import numpy as np
-from astropy import constants as c
 from astropy import units as u
-from astropy.coordinates import FK5, ICRS, SkyCoord
-from astropy.io import fits
-from astropy.table import Table
+from astropy.coordinates import ICRS, SkyCoord
 from astropy.wcs import WCS
 
 
@@ -172,16 +165,16 @@ class DECamtile:
         return ccd_cent_xy
 
 
-class CCDProb:
-    """
-    Class :: Instantiate a CCDProb object that will allow us to calculate the
-             probability content in a single CCD.
-    """
-
-    def __init__(self, RA, Dec):
-        self.RA = RA
-        self.Dec = Dec
-        self.ccd_size = np.array([2046, 4094])
+# class CCDProb:
+#     """
+#     Class :: Instantiate a CCDProb object that will allow us to calculate the
+#              probability content in a single CCD.
+#     """
+#
+#     def __init__(self, RA, Dec):
+#         self.RA = RA
+#         self.Dec = Dec
+#         self.ccd_size = np.array([2046, 4094])
 
 
 def get_decam_ccds(ra, dec, save_footprint=False):
@@ -229,7 +222,7 @@ def get_decam_ccds(ra, dec, save_footprint=False):
     return np.transpose(offsets, (2, 0, 1))
 
 
-def get_quadrant_ipix(nside, ra, dec):
+def get_decam_quadrant_ipix(nside, ra, dec):
     ccd_coords = get_decam_ccds(0, 0)
 
     skyoffset_frames = SkyCoord(ra, dec, unit=u.deg).skyoffset_frame()
@@ -247,67 +240,67 @@ def get_quadrant_ipix(nside, ra, dec):
     return ipixs
 
 
-def get_ccdcenters_radec(filename):
-    hdul = fits.open(filename)
-    nccds = len(hdul) - 1
-    ccd_centers = dict()
-    for i in range(1, nccds + 1):
-        w = WCS(hdul[i].header)
-        ccdnum = hdul[i].header["CCDNUM"]
-        coords = np.array(
-            w.wcs_pix2world(
-                hdul[i].header["NAXIS1"] / 2, hdul[i].header["NAXIS2"] / 2, 0
-            )
-        )
-        ccd_centers[str(ccdnum)] = coords
-    hdul.close()
-    return ccd_centers
+# def get_ccdcenters_radec(filename):
+#     hdul = fits.open(filename)
+#     nccds = len(hdul) - 1
+#     ccd_centers = dict()
+#     for i in range(1, nccds + 1):
+#         w = WCS(hdul[i].header)
+#         ccdnum = hdul[i].header["CCDNUM"]
+#         coords = np.array(
+#             w.wcs_pix2world(
+#                 hdul[i].header["NAXIS1"] / 2, hdul[i].header["NAXIS2"] / 2, 0
+#             )
+#         )
+#         ccd_centers[str(ccdnum)] = coords
+#     hdul.close()
+#     return ccd_centers
 
 
-def create_region_file(filename):
-    hdul = fits.open(filename)
-    nccds = len(hdul) - 1
-    for i in range(1, nccds + 1):
-        w = WCS(hdul[i].header)
-        w.footprint_to_file(
-            filename="region_files/footprint_" + str(hdul[i].header["CCDNUM"]) + ".reg"
-        )
-    hdul.close()
+# def create_region_file(filename):
+#     hdul = fits.open(filename)
+#     nccds = len(hdul) - 1
+#     for i in range(1, nccds + 1):
+#         w = WCS(hdul[i].header)
+#         w.footprint_to_file(
+#             filename="region_files/footprint_" + str(hdul[i].header["CCDNUM"]) + ".reg"
+#         )
+#     hdul.close()
+#
+#
+# def get_cd(filename):
+#     hdul = fits.open(filename)
+#     w = WCS(hdul[1].header)
+#     hdul.close()
+#     return w.wcs.cd
 
 
-def get_cd(filename):
-    hdul = fits.open(filename)
-    w = WCS(hdul[1].header)
-    hdul.close()
-    return w.wcs.cd
-
-
-def get_ccdcenters_xy(filename):
-    "Calculates the x,y coordinates of the CCD center given the RA,Dec of the center and reference point.Uses Calabretta and Greisen(2002) eqns. 5,12,13,54"
-    ccd_centers_xy = dict()
-    phi_p = 180 * u.deg
-    ccd_centers_radec = get_ccdcenters_radec(filename)
-    hdul = fits.open(filename)
-    alpha_p = hdul[1].header["CRVAL1"] * u.deg
-    delta_p = hdul[1].header["CRVAL2"] * u.deg
-    ccdnums = ccd_centers_radec.keys()
-    for ccdnum in ccdnums:
-        alpha = ccd_centers_radec[ccdnum][0] * u.deg
-        delta = ccd_centers_radec[ccdnum][1] * u.deg
-        phi = phi_p + np.arctan2(
-            -np.cos(delta) * np.sin(alpha - alpha_p),
-            np.sin(delta) * np.cos(delta_p)
-            - np.cos(delta) * np.sin(delta_p) * np.cos(alpha - alpha_p),
-        )
-        theta = np.arcsin(
-            np.sin(delta) * np.sin(delta_p)
-            + np.cos(delta) * np.cos(delta_p) * np.cos(alpha - alpha_p)
-        )
-        R_theta = (1 * u.rad / np.tan(theta)).to(u.deg)
-        x = R_theta * np.sin(phi)
-        y = -R_theta * np.cos(phi)
-        ccd_centers_xy[ccdnum] = [x.value, y.value]
-    return ccd_centers_xy
+# def get_ccdcenters_xy(filename):
+#     "Calculates the x,y coordinates of the CCD center given the RA,Dec of the center and reference point.Uses Calabretta and Greisen(2002) eqns. 5,12,13,54"
+#     ccd_centers_xy = dict()
+#     phi_p = 180 * u.deg
+#     ccd_centers_radec = get_ccdcenters_radec(filename)
+#     hdul = fits.open(filename)
+#     alpha_p = hdul[1].header["CRVAL1"] * u.deg
+#     delta_p = hdul[1].header["CRVAL2"] * u.deg
+#     ccdnums = ccd_centers_radec.keys()
+#     for ccdnum in ccdnums:
+#         alpha = ccd_centers_radec[ccdnum][0] * u.deg
+#         delta = ccd_centers_radec[ccdnum][1] * u.deg
+#         phi = phi_p + np.arctan2(
+#             -np.cos(delta) * np.sin(alpha - alpha_p),
+#             np.sin(delta) * np.cos(delta_p)
+#             - np.cos(delta) * np.sin(delta_p) * np.cos(alpha - alpha_p),
+#         )
+#         theta = np.arcsin(
+#             np.sin(delta) * np.sin(delta_p)
+#             + np.cos(delta) * np.cos(delta_p) * np.cos(alpha - alpha_p)
+#         )
+#         R_theta = (1 * u.rad / np.tan(theta)).to(u.deg)
+#         x = R_theta * np.sin(phi)
+#         y = -R_theta * np.cos(phi)
+#         ccd_centers_xy[ccdnum] = [x.value, y.value]
+#     return ccd_centers_xy
 
 
 def ccd_xy_to_radec(alpha_p, delta_p, ccd_centers_xy):
@@ -354,13 +347,13 @@ def ccd_xy_to_radec(alpha_p, delta_p, ccd_centers_xy):
     return ccd_centers_radec
 
 
-def calculate_residuals(ccd_cent_code, ccd_cent_wcs):
-    residuals = np.empty([len(ccd_cent_code), 2])
-    for i, ccdnum in enumerate(ccd_cent_code.keys()):
-        residuals[i] = np.array(
-            [
-                np.abs(ccd_cent_code[ccdnum][0] - ccd_cent_wcs[ccdnum][0]),
-                np.abs(ccd_cent_code[ccdnum][1] - ccd_cent_wcs[ccdnum][1]),
-            ]
-        )
-    return residuals
+# def calculate_residuals(ccd_cent_code, ccd_cent_wcs):
+#     residuals = np.empty([len(ccd_cent_code), 2])
+#     for i, ccdnum in enumerate(ccd_cent_code.keys()):
+#         residuals[i] = np.array(
+#             [
+#                 np.abs(ccd_cent_code[ccdnum][0] - ccd_cent_wcs[ccdnum][0]),
+#                 np.abs(ccd_cent_code[ccdnum][1] - ccd_cent_wcs[ccdnum][1]),
+#             ]
+#         )
+#     return residuals

--- a/gwemopt/chipgaps/ztf.py
+++ b/gwemopt/chipgaps/ztf.py
@@ -14,21 +14,16 @@
 # with this program; if not, write to the Free Software Foundation, Inc.,
 # 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 
-from __future__ import print_function
-
-import os
-
-# import cPickle as pickle
-import pickle
+"""
+This module contains the ZTFtile class, which is used to calculate
+ZTF chip gaps and overlaps.
+"""
 
 import astropy
-import healpy
 import healpy as hp
 import numpy as np
-from astropy import constants as c
 from astropy import units as u
 from astropy.coordinates import ICRS, SkyCoord
-from astropy.table import Table
 from astropy.wcs import WCS
 
 
@@ -282,7 +277,7 @@ def get_ztf_quadrants():
     return np.transpose(offsets, (2, 0, 1))
 
 
-def get_quadrant_ipix(nside, ra, dec, subfield_ids=None):
+def get_ztf_quadrant_ipix(nside, ra, dec, subfield_ids=None):
     quadrant_coords = get_ztf_quadrants()
 
     skyoffset_frames = SkyCoord(ra, dec, unit=u.deg).skyoffset_frame()
@@ -295,8 +290,8 @@ def get_quadrant_ipix(nside, ra, dec, subfield_ids=None):
 
     ipixs = []
     for subfield_id, xyz in enumerate(quadrant_xyz):
-        if not subfield_ids is None:
-            if not subfield_id in subfield_ids:
+        if subfield_ids is not None:
+            if subfield_id not in subfield_ids:
                 continue
         ipix = hp.query_polygon(nside, xyz)
         ipixs.append(ipix.tolist())

--- a/gwemopt/moc.py
+++ b/gwemopt/moc.py
@@ -11,7 +11,6 @@ from gwemopt.utils.pixels import getCirclePixels, getSquarePixels
 
 def create_moc(params, map_struct=None):
     nside = params["nside"]
-    npix = hp.nside2npix(nside)
 
     if params["doMinimalTiling"]:
         prob = map_struct["prob"]
@@ -27,16 +26,6 @@ def create_moc(params, map_struct=None):
         prob_cumsum = np.cumsum(prob_sorted)
         index = np.argmin(np.abs(prob_cumsum - cl)) + 1
         prob_indexes = prob_indexes[: index + 1]
-
-    if "doUsePrimary" in params:
-        doUsePrimary = params["doUsePrimary"]
-    else:
-        doUsePrimary = False
-
-    if "doUseSecondary" in params:
-        doUseSecondary = params["doUseSecondary"]
-    else:
-        doUseSecondary = False
 
     moc_structs = {}
     for telescope in params["telescopes"]:
@@ -63,17 +52,17 @@ def create_moc(params, map_struct=None):
             )
             for ii, tess in enumerate(tesselation):
                 index, ra, dec = tess[0], tess[1], tess[2]
-                if (telescope == "ZTF") and doUsePrimary and (index > 880):
+                if (telescope == "ZTF") and params["doUsePrimary"] and (index > 880):
                     continue
-                if (telescope == "ZTF") and doUseSecondary and (index < 1000):
+                if (telescope == "ZTF") and params["doUseSecondary"] and (index < 1000):
                     continue
                 moc_struct[index] = moclists[ii]
         else:
             for ii, tess in enumerate(tesselation):
                 index, ra, dec = tess[0], tess[1], tess[2]
-                if (telescope == "ZTF") and doUsePrimary and (index > 880):
+                if (telescope == "ZTF") and params["doUsePrimary"] and (index > 880):
                     continue
-                if (telescope == "ZTF") and doUseSecondary and (index < 1000):
+                if (telescope == "ZTF") and params["doUseSecondary"] and (index < 1000):
                     continue
                 index = index.astype(int)
                 moc_struct[index] = Fov2Moc(
@@ -102,7 +91,6 @@ def create_moc(params, map_struct=None):
             csm[sort_idx] = np.cumsum(tile_probs[sort_idx])
             ipix_keep = np.where(csm <= cl)[0]
 
-            probs = []
             moc_struct = {}
             cnt = 0
             for ii, key in enumerate(keys):

--- a/gwemopt/moc.py
+++ b/gwemopt/moc.py
@@ -4,7 +4,6 @@ import healpy as hp
 import numpy as np
 from joblib import Parallel, delayed
 
-import gwemopt.chipgaps.ztf
 import gwemopt.tiles
 from gwemopt.chipgaps import get_decam_quadrant_ipix, get_ztf_quadrant_ipix
 from gwemopt.utils.pixels import getCirclePixels, getSquarePixels


### PR DESCRIPTION
There are several scripts named "tile/tiling". This PR groups the two "tiling" scripts for decam/ztf, which get called when calculating chip gaps, and puts them into a dedicated directory called `chipgaps`. It comments out several Decam functions which are never actually used anywhere, and renames the identically-named `get_quadrant_ipix` function in each script to differently-named `get_decam_quadrant_ipix` and `get_ztf_quadrant_ipix`. Lastly, it updates `moc.py` to import the newly-named functions, and as a bonus deletes from unused variables in `moc.py`.