### PR TITLE
Parallelization optimization

### DIFF
--- a/gwemopt/moc.py
+++ b/gwemopt/moc.py
@@ -47,7 +47,11 @@ def create_moc(params, map_struct=None):
                 tesselation = tesselation[idxs, :]
 
         if params["doParallel"]:
-            moclists = Parallel(n_jobs=params["Ncores"], backend="multiprocessing", batch_size=int(len(tesselation) / params["Ncores"]) + 1)(
+            moclists = Parallel(
+                n_jobs=params["Ncores"],
+                backend="multiprocessing",
+                batch_size=int(len(tesselation) / params["Ncores"]) + 1,
+            )(
                 delayed(Fov2Moc)(
                     params, config_struct, telescope, tess[1], tess[2], nside
                 )

--- a/gwemopt/moc.py
+++ b/gwemopt/moc.py
@@ -47,7 +47,7 @@ def create_moc(params, map_struct=None):
                 tesselation = tesselation[idxs, :]
 
         if params["doParallel"]:
-            moclists = Parallel(n_jobs=params["Ncores"])(
+            moclists = Parallel(n_jobs=params["Ncores"], backend="multiprocessing", batch_size=int(len(tesselation) / params["Ncores"]) + 1)(
                 delayed(Fov2Moc)(
                     params, config_struct, telescope, tess[1], tess[2], nside
                 )

--- a/gwemopt/segments.py
+++ b/gwemopt/segments.py
@@ -291,8 +291,8 @@ def get_segments_tiles(params, config_struct, tile_struct):
     )
 
     if params["doParallel"]:
-        tilesegmentlists = Parallel(n_jobs=params["Ncores"])(
-            delayed(get_segments_tile)(config_struct, observatory, radec, segmentlist)
+        tilesegmentlists = Parallel(n_jobs=params["Ncores"], backend="multiprocessing", batch_size=int(len(radecs) / params["Ncores"]) + 1)(
+            delayed(get_segments_tile)(config_struct, observatory, radec, segmentlist, params["airmass"])
             for radec in radecs
         )
         for ii, key in enumerate(keys):

--- a/gwemopt/segments.py
+++ b/gwemopt/segments.py
@@ -291,8 +291,14 @@ def get_segments_tiles(params, config_struct, tile_struct):
     )
 
     if params["doParallel"]:
-        tilesegmentlists = Parallel(n_jobs=params["Ncores"], backend="multiprocessing", batch_size=int(len(radecs) / params["Ncores"]) + 1)(
-            delayed(get_segments_tile)(config_struct, observatory, radec, segmentlist, params["airmass"])
+        tilesegmentlists = Parallel(
+            n_jobs=params["Ncores"],
+            backend="multiprocessing",
+            batch_size=int(len(radecs) / params["Ncores"]) + 1,
+        )(
+            delayed(get_segments_tile)(
+                config_struct, observatory, radec, segmentlist, params["airmass"]
+            )
             for radec in radecs
         )
         for ii, key in enumerate(keys):

--- a/gwemopt/utils/pixels.py
+++ b/gwemopt/utils/pixels.py
@@ -94,7 +94,7 @@ def getRegionPixels(
 
         patch.append(
             matplotlib.patches.PathPatch(
-                path, alpha=alpha, color=color, fill=True, zorder=3, edgecolor=edgecolor
+                path, alpha=alpha, facecolor=color, fill=True, zorder=3, edgecolor=edgecolor
             )
         )
 
@@ -155,7 +155,7 @@ def getCirclePixels(
     # path = matplotlib.path.Path(xyz[:,1:3])
     path = matplotlib.path.Path(xy)
     patch = matplotlib.patches.PathPatch(
-        path, alpha=alpha, color=color, fill=True, zorder=3, edgecolor=edgecolor
+        path, alpha=alpha, facecolor=color, fill=True, zorder=3, edgecolor=edgecolor
     )
 
     area = np.pi * radius**2
@@ -233,7 +233,7 @@ def getRectanglePixels(
     xy[:, 1] = y
     path = matplotlib.path.Path(xy)
     patch = matplotlib.patches.PathPatch(
-        path, alpha=alpha, color=color, fill=True, zorder=3, edgecolor=edgecolor
+        path, alpha=alpha, facecolor=color, fill=True, zorder=3, edgecolor=edgecolor
     )
 
     return ipix, radecs, patch, area
@@ -309,7 +309,7 @@ def getSquarePixels(
     xy[:, 1] = y
     path = matplotlib.path.Path(xy)
     patch = matplotlib.patches.PathPatch(
-        path, alpha=alpha, color=color, fill=True, zorder=3, edgecolor=edgecolor
+        path, alpha=alpha, facecolor=color, fill=True, zorder=3, edgecolor=edgecolor
     )
 
     return ipix, radecs, patch, area

--- a/gwemopt/utils/pixels.py
+++ b/gwemopt/utils/pixels.py
@@ -94,7 +94,12 @@ def getRegionPixels(
 
         patch.append(
             matplotlib.patches.PathPatch(
-                path, alpha=alpha, facecolor=color, fill=True, zorder=3, edgecolor=edgecolor
+                path,
+                alpha=alpha,
+                facecolor=color,
+                fill=True,
+                zorder=3,
+                edgecolor=edgecolor,
             )
         )
 


### PR DESCRIPTION
Added some arguments to `joblib.Parallel()` calls in `moc.py` and `segments.py` to for faster runtimes.

After some benchmarking, it was determined that a function of the number of tasks and the number of cores was a reasonable way to determining the batch size (better than using a fixed batch size for all core counts, or `joblib`'s dynamic batch size, which is too slow for large number of cores).  The batch size function in this commit scales well to 16 cores, and the fastest performance was recorded when running on 32 cores (testing extended to 64 and 128 core runs, but slower overall times were observed at these scales).  Using the `multiprocessing` backend (instead of the default `loky`) also bought a small improvement.  Overall speedup due to this improvement was ~3-14x when compared to the previous version, with the highest impacts at larger core numbers.  This update was tested with both the default, 13,902-pointing DECam tessellation, and a custom DECam tessellation of 45,713 pointings.

This commit also adds a missing argument in a function call in `segments.py`, and changes a `matplotlib.patches.PathPatch` keyword in `pixels.py` to alleviate `matplotlib` warning messages.